### PR TITLE
修正yum源问题

### DIFF
--- a/OracleShellInstall.sh
+++ b/OracleShellInstall.sh
@@ -817,30 +817,33 @@ InstallRPM() {
     c1 "The ISO file is not mounted on system." red
     exit 99
   else
-    if [ ! -f /etc/yum.repos.d/local.repo ]; then
-      if [ "${OS_VERSION}" = "linux6" ] || [ "${OS_VERSION}" = "linux7" ]; then
-        {
-          echo "[server]"
-          echo "name=server"
-          echo "baseurl=file://""${mountPatch}"
-          echo "enabled=1"
-          echo "gpgcheck=1"
-        } >/etc/yum.repos.d/local.repo
-      elif [ "${OS_VERSION}" = "linux8" ]; then
-        {
-          echo "[BaseOS]"
-          echo "name=BaseOS"
-          echo "baseurl=file:///${mountPatch}/BaseOS"
-          echo "enabled=1"
-          echo "gpgcheck=1"
-          echo "[AppStream]"
-          echo "name=AppStream"
-          echo "baseurl=file:///${mountPatch}/AppStream"
-          echo "enabled=1"
-          echo "gpgcheck=1"
-        } >/etc/yum.repos.d/local.repo
-      fi
-      rpm --import "${mountPatch}"/RPM-GPG-KEY-redhat-release
+    ## move all repo bak
+    mkdir /etc/yum.repos.d/bak -p
+    mv /etc/yum.repos.d/* /etc/yum.repos.d/bak
+    ##if [ ! -f /etc/yum.repos.d/local.repo ]; then
+    if [ "${OS_VERSION}" = "linux6" ] || [ "${OS_VERSION}" = "linux7" ]; then
+      {
+        echo "[server]"
+        echo "name=server"
+        echo "baseurl=file://""${mountPatch}"
+        echo "enabled=1"
+        echo "gpgcheck=0"
+      } >/etc/yum.repos.d/local.repo
+    elif [ "${OS_VERSION}" = "linux8" ]; then
+      {
+        echo "[BaseOS]"
+        echo "name=BaseOS"
+        echo "baseurl=file:///${mountPatch}/BaseOS"
+        echo "enabled=1"
+        echo "gpgcheck=0"
+        echo "[AppStream]"
+        echo "name=AppStream"
+        echo "baseurl=file:///${mountPatch}/AppStream"
+        echo "enabled=1"
+        echo "gpgcheck=0"
+      } >/etc/yum.repos.d/local.repo
+      ##fi
+      ##rpm --import "${mountPatch}"/RPM-GPG-KEY-redhat-release
     fi
     if [ "${OS_VERSION}" = "linux6" ]; then
       if [ "${TuXingHua}" = "y" ] || [ "${TuXingHua}" = "Y" ]; then


### PR DESCRIPTION
1.yum 导入key的时候我这里失败了，配置文件可以设置gpgcheck=0
2.在/etc/yum.repos.d/ 目录下存在其他失效的.repo文件，且顺序优先的的话，会导致安装失败。可以考虑新建目录把已有repo文件移进去，或新建的repo文件名以a开头，提升优先级。

现已修正。